### PR TITLE
Añadida otra dependencia

### DIFF
--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -1,3 +1,4 @@
 version = 1
 version_url = 'https://raw.githubusercontent.com/MASTito/db_cleaner/master/facturascripts.ini'
 update_url = 'https://github.com/MASTito/db_cleaner/archive/master.zip'
+require = 'facturacion_base,presupuestos_y_pedidos'


### PR DESCRIPTION
Desde que se hace uso del require_all para reemplazar a los require_model, si no se cumplen bien las dependencias se queda FacturaScripts KO.